### PR TITLE
Update md2ipynb.py. Fix .md hyperlinks, change extension to .ipynb

### DIFF
--- a/md2ipynb.py
+++ b/md2ipynb.py
@@ -8,6 +8,10 @@ import time
 import notedown
 import nbformat
 
+def hyperlink_md_2_ipynb(string):
+    # replace .md to .ipynb in hyperlinks
+    return string.replace(".md)", ".ipynb)")
+
 reader = notedown.MarkdownReader(match='strict')
 
 if __name__ == '__main__':
@@ -29,6 +33,11 @@ if __name__ == '__main__':
     # read
     with open(input_fn, 'r') as f:
         notebook = reader.read(f)
+
+    # fix hyperlink extension (.md to .ipynb) for markdown cells
+    for c in notebook.cells:
+        if c.cell_type == "markdown":
+            c.source = hyperlink_md_2_ipynb(c.source)
 
     if do_eval and not any([i in input_fn for i in ignore_execution]):
         tic = time.time()


### PR DESCRIPTION
In the previous versions, the hyperlinks in the .ipynb markdown cells are still pointing at .md files. If someone is reading the .ipynb notebooks extracted from d2l-zh.zip, he won't be able to find the .md files locally.

Therefore, I propose to change the hyperlinks that are pointing at .md to .ipynb.

I tested this code in a few .md files and it seems to work properly.